### PR TITLE
Call `savefigs` module as if it were the `savefigs` fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 * Add `py.typed` file
+* Make the module callable, allowing the concise `import savefigs; savefigs()`
 
 ## [0.2.0] (2021-10-22)
 

--- a/savefigs/__init__.py
+++ b/savefigs/__init__.py
@@ -8,6 +8,7 @@ import math
 import os
 import sys
 import tempfile
+import types
 import warnings
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Union
@@ -236,7 +237,7 @@ def savefigs(
 # https://stackoverflow.com/a/48100440
 
 
-class _CallSavefigs(sys.modules[__name__].__class__):
+class _CallSavefigs(types.ModuleType):
     @functools.wraps(savefigs)
     def __call__(self, *args, **kwargs):  # module callable
         kwargs["stack_pos"] = kwargs.get("stack_pos", 2)  # new default

--- a/savefigs/__init__.py
+++ b/savefigs/__init__.py
@@ -102,6 +102,7 @@ def savefigs(
     clobber: bool = True,
     noclobber_method: str = "raise",
     debug: bool = False,
+    stack_pos: int = 1,
 ) -> None:
     """Save all open Matplotlib figures.
 
@@ -140,6 +141,9 @@ def savefigs(
         What to do when `clobber=False`.
     debug
         Whether to print info/debug messages (to stdout).
+    stack_pos
+        Stack position to look at when detecting the caller
+        to determine what to use for the default `stem_prefix`.
     """
     if debug:
         logger.setLevel(logging.DEBUG)
@@ -158,7 +162,7 @@ def savefigs(
         stem_prefix = ""
 
         # Attempt to detect caller file
-        caller_frame_info = inspect.stack()[1]
+        caller_frame_info = inspect.stack()[stack_pos]
         caller = caller_frame_info.filename
         logger.info(f"caller: {caller!r}")
         if _caller_is_ipykernel_interactive(caller) or _caller_is_ipython(caller):
@@ -235,6 +239,7 @@ def savefigs(
 class _CallSavefigs(sys.modules[__name__].__class__):
     @functools.wraps(savefigs)
     def __call__(self, *args, **kwargs):  # module callable
+        kwargs["stack_pos"] = kwargs.get("stack_pos", 2)  # new default
         savefigs(*args, **kwargs)
 
 

--- a/savefigs/__init__.py
+++ b/savefigs/__init__.py
@@ -1,6 +1,7 @@
 """
 Save all open Matplotlib figures
 """
+import functools
 import inspect
 import logging
 import math
@@ -222,3 +223,19 @@ def savefigs(
             fig.savefig(p, **savefig_kwargs)
 
     # TODO: Return paths?
+
+
+# Set up as a callable module, so that the more-concise
+# `import savefigs; savefigs()`
+# can be used, instead of
+# `from savefigs import savefigs; savefigs()`
+# https://stackoverflow.com/a/48100440
+
+
+class _CallSavefigs(sys.modules[__name__].__class__):
+    @functools.wraps(savefigs)
+    def __call__(self, *args, **kwargs):  # module callable
+        savefigs(*args, **kwargs)
+
+
+sys.modules[__name__].__class__ = _CallSavefigs

--- a/tests/test_call_module.py
+++ b/tests/test_call_module.py
@@ -16,8 +16,9 @@ def test_defaults():
     plt.close(fig)
 
     figs = list(Path().cwd().glob("*.png"))
-    assert len(figs) == 1
-    assert figs[0].name == "test_savefigs_fig1.png"
-
-    for p_fig in figs:
-        os.remove(p_fig)
+    try:
+        assert len(figs) == 1
+        assert figs[0].name == "test_call_module_fig1.png"
+    finally:
+        for p_fig in figs:
+            os.remove(p_fig)

--- a/tests/test_call_module.py
+++ b/tests/test_call_module.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+import savefigs
+
+mpl.use("Agg")
+
+
+def test_defaults():
+    # Keep consistent with the test in `test_savefigs.py`
+    fig = plt.figure()
+    savefigs()
+    plt.close(fig)
+
+    figs = list(Path().cwd().glob("*.png"))
+    assert len(figs) == 1
+    assert figs[0].name == "test_savefigs_fig1.png"
+
+    for p_fig in figs:
+        os.remove(p_fig)

--- a/tests/test_savefigs.py
+++ b/tests/test_savefigs.py
@@ -25,11 +25,12 @@ def test_defaults():
     plt.close(fig)
 
     figs = list(Path().cwd().glob("*.png"))
-    assert len(figs) == 1
-    assert figs[0].name == "test_savefigs_fig1.png"
-
-    for p_fig in figs:
-        os.remove(p_fig)
+    try:
+        assert len(figs) == 1
+        assert figs[0].name == "test_savefigs_fig1.png"
+    finally:
+        for p_fig in figs:
+            os.remove(p_fig)
 
 
 def test_save_dir(tmpdir):


### PR DESCRIPTION
To allow the more concise `import savefigs; savefigs()` (just for fun)